### PR TITLE
disable KVM_FEATURE_ASYNC_PF_INT in CPUID

### DIFF
--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -148,6 +148,7 @@ impl CpuidTransformer for AmdCpuidTransformer {
             leaf_0x8000001d::LEAF_NUM => Some(amd::update_extended_cache_topology_entry),
             leaf_0x8000001e::LEAF_NUM => Some(amd::update_extended_apic_id_entry),
             0x8000_0002..=0x8000_0004 => Some(common::update_brand_string_entry),
+            0x4000_0001 => Some(common::disable_kvm_feature_async_pf),
             _ => None,
         }
     }

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -70,6 +70,19 @@ pub fn update_brand_string_entry(
     Ok(())
 }
 
+// KVM feature bits
+#[cfg(target_arch = "x86_64")]
+const KVM_FEATURE_ASYNC_PF_INT_BIT: u32 = 14;
+
+pub fn disable_kvm_feature_async_pf(
+    entry: &mut kvm_cpuid_entry2,
+    vm_spec: &VmSpec,
+) -> Result<(), Error> {
+    entry.eax.write_bit(KVM_FEATURE_ASYNC_PF_INT_BIT, false);
+
+    Ok(())
+}
+
 pub fn update_cache_parameters_entry(
     entry: &mut kvm_cpuid_entry2,
     vm_spec: &VmSpec,

--- a/src/cpuid/src/transformer/intel.rs
+++ b/src/cpuid/src/transformer/intel.rs
@@ -126,6 +126,7 @@ impl CpuidTransformer for IntelCpuidTransformer {
             leaf_0xa::LEAF_NUM => Some(intel::update_perf_mon_entry),
             leaf_0xb::LEAF_NUM => Some(intel::update_extended_topology_entry),
             0x8000_0002..=0x8000_0004 => Some(common::update_brand_string_entry),
+            0x4000_0001 => Some(common::disable_kvm_feature_async_pf),
             _ => None,
         }
     }


### PR DESCRIPTION
## Reason

https://github.com/firecracker-microvm/firecracker/issues/3020
https://github.com/firecracker-microvm/firecracker/issues/3043
https://github.com/cloud-hypervisor/cloud-hypervisor/pull/2498
https://github.com/jeromegn/firecracker/commit/d6e73e4405d8f119605291750099f94d6b9715c8
